### PR TITLE
Add support for theta in var names

### DIFF
--- a/src/TIVarFile.cpp
+++ b/src/TIVarFile.cpp
@@ -202,6 +202,7 @@ namespace tivars
         {
             newName = "FILE" + (type.getExts().empty() ? "" : type.getExts()[0]);
         }
+        // Here we handle various theta chars. Note thata in TI-ASCII, theta is at 0x5B which is "[" in ASCII.
         newName = std::regex_replace(newName, std::regex("(\u03b8|\u0398|\u03F4|\u1DBF)"), "[");
         newName = std::regex_replace(newName, std::regex("[^[a-zA-Z0-9]"), "");
         if (newName.length() > sizeof(var_entry_t::varname) || newName.empty() || is_numeric(newName.substr(0, 1)))

--- a/src/TIVarFile.cpp
+++ b/src/TIVarFile.cpp
@@ -202,10 +202,11 @@ namespace tivars
         {
             newName = "FILE" + (type.getExts().empty() ? "" : type.getExts()[0]);
         }
-        newName = std::regex_replace(newName, std::regex("[^a-zA-Z0-9]"), "");
+        newName = std::regex_replace(newName, std::regex("(\u03b8|\u0398|\u03F4|\u1DBF)"), "[");
+        newName = std::regex_replace(newName, std::regex("[^[a-zA-Z0-9]"), "");
         if (newName.length() > sizeof(var_entry_t::varname) || newName.empty() || is_numeric(newName.substr(0, 1)))
         {
-            throw std::invalid_argument("Invalid name given. 8 chars (A-Z, 0-9) max, starting by a letter");
+            throw std::invalid_argument("Invalid name given. 8 chars (A-Z, 0-9, θ) max, starting by a letter or θ.");
         }
 
         for (auto & c: newName) c = (char) toupper(c);

--- a/tests.cpp
+++ b/tests.cpp
@@ -354,5 +354,12 @@ int main(int argc, char** argv)
         assert(pythonFromTest2.getReadableContent() == "import sys\nprint(sys.version)\n");
     }
 
+    {
+        TIVarFile testTheta = TIVarFile::createNew(TIVarType::createFromName("Program"), "θΘϴᶿ");
+        uint8_t testThetaVarName[8] = {0x5B, 0x5B, 0x5B, 0x5B};
+        cout << "testTheta.getVarEntry().varname : " << testTheta.getVarEntry().varname << endl;
+        assert(std::equal(testTheta.getVarEntry().varname, testTheta.getVarEntry().varname + 8, testThetaVarName));
+    }
+
     return 0;
 }


### PR DESCRIPTION
Any of "θΘϴᶿ" can be used to specify the theta character that appears on-calc; these are the "theta" symbols with codepoints below `\uFFFF`.

As a side effect, "[" can also be used, since theta takes up the slot in TI's encoding that "[" would in regular ASCII.