### PR TITLE
Make "|" optionnal in regex

### DIFF
--- a/src/TypeHandlers/TH_Tokenized.cpp
+++ b/src/TypeHandlers/TH_Tokenized.cpp
@@ -29,7 +29,7 @@ namespace tivars
         uint8_t lengthOfLongestTokenName;
         std::vector<uint8_t> firstByteOfTwoByteTokens;
         const uint16_t squishedASMTokens[] = { 0xBB6D, 0xEF69, 0xEF7B }; // 83+/84+, 84+CSE, CE
-        const std::regex toPrettifyRX(R"(\[?\|([a-zA-Z]+)\]?)");
+        const std::regex toPrettifyRX(R"(\[?\|?([a-zA-Z]+)\]?)");
     }
 
     /* TODO: handle TI-Innovator Send( exception for in-strings tokenization (=> not shortest tokens) */


### PR DESCRIPTION
With the actual `programs_tokens.csv` :
- some characters like `p`, `z`, `t`... 
- are replaced with `[p]`, `[z]`, `[t]`...
- and not like `[|p]`, `[|z]`, `[|t]`...

This PR make the `|` optional in the regex

Here is an example :

https://onlinegdb.com/xbj6NZDNJ